### PR TITLE
Restore selection correctly even when wrapping asymmetrically

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -121,6 +121,8 @@ for (const type of ['textarea', 'input', 'contenteditable'] as const) {
 		const field = getField(type, 'W{O}A');
 		wrapFieldSelection(field, '[', ']');
 		t.equal(getState(field), 'W[{O}]A');
+		wrapFieldSelection(field, '<p>', '</p>');
+		t.equal(getState(field), 'W[<p>{O}</p>]A');
 		t.end();
 	});
 

--- a/index.ts
+++ b/index.ts
@@ -94,7 +94,7 @@ function wrapFieldSelectionNative(
 
 	// Restore the selection around the previously-selected text
 	field.selectionStart = selectionStart! + wrap.length;
-	field.selectionEnd = selectionEnd! + wrapEnd.length;
+	field.selectionEnd = selectionEnd! + wrap.length;
 }
 
 function collapseCursor(selection: Selection, range: Range, toStart: boolean) {


### PR DESCRIPTION
Fixes: #31 